### PR TITLE
improvement: Refactor board_info.rs for better maintainability and readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "osdev"
 version = "0.0.1"
+dependencies = [
+ "lazy_static",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ device = []
 aarch64 = []
 
 [dependencies]
+lazy_static = "1.4"
 
 [profile.test]
 features = ["host"]

--- a/src/diagnostic/board_info.rs
+++ b/src/diagnostic/board_info.rs
@@ -1,82 +1,118 @@
 use crate::common::stream;
 use crate::io::uart;
-use crate::meta::board_info;
-use crate::meta::cpu_info;
+use crate::meta::{board_info, cpu_info};
 
-fn print_cache_info(cache: &cpu_info::CacheInfo) {
-  stream::println!("Cache {} - {}", cache.level, cache.cache_type);
+const BYTES_PER_KIB: usize = 1024;
+
+/// Represents and displays a memory region
+struct MemoryRegion {
+  base_address: usize,
+  size_bytes: usize,
+}
+
+impl MemoryRegion {
+  fn new(base_address: u32, size_bytes: u32) -> Self {
+    Self {
+      base_address: base_address as usize,
+      size_bytes: size_bytes as usize,
+    }
+  }
+
+  fn display(&self, region_name: &str) {
+    stream::println!("{}:", region_name);
+    stream::println!("\tBase address: {:#010x}", self.base_address);
+    stream::println!("\tSize: {} bytes", self.size_bytes);
+  }
+}
+
+/// Handles the display of cache information
+fn display_cache_info(cache: &cpu_info::CacheInfo) {
+  stream::println!("Cache Level {} - {}", cache.level, cache.cache_type);
+
   if !cache.exists {
-    stream::println!("Cache do not exist");
+    stream::println!("Cache does not exist");
     return;
   }
 
-  stream::println!("Line size (bytes): {}", cache.line_size_bytes);
-  stream::println!("Associativity: {}", cache.associativity);
-  stream::println!("Number of sets: {}", cache.num_sets);
+  stream::println!("Size Information:");
+  stream::println!("\tLine size: {} bytes", cache.line_size_bytes);
+  stream::println!("\tAssociativity: {}", cache.associativity);
+  stream::println!("\tNumber of sets: {}", cache.num_sets);
   stream::println!(
-    "Total size: {} bytes = {} KiB",
+    "\tTotal size: {} bytes ({} KiB)",
     cache.total_size_bytes,
-    cache.total_size_bytes / 1024
+    cache.total_size_bytes / BYTES_PER_KIB as u32
   );
-  stream::println!(
-    "Write allocation supported: {}",
-    cache.write_alloc_supported
-  );
-  stream::println!("Read allocation supported: {}", cache.read_alloc_supported);
-  stream::println!("Write back supported: {}", cache.write_back_supported);
-  stream::println!(
-    "Write through supported: {}",
-    cache.write_through_supported
-  );
+
+  stream::println!("Cache Capabilities:");
+  stream::println!("\tWrite allocation: {}", cache.write_alloc_supported);
+  stream::println!("\tRead allocation: {}", cache.read_alloc_supported);
+  stream::println!("\tWrite back: {}", cache.write_back_supported);
+  stream::println!("\tWrite through: {}", cache.write_through_supported);
 }
 
-pub fn test_board_info() -> ! {
-  uart::pl011_init();
-  stream::println!("Test Board information");
-
-  let board_info = board_info::raspi_board_info();
+/// Displays general board information including memory regions
+fn display_board_info(board_info: &board_info::RaspiBoardInfo) {
   stream::println!("===================================");
+  stream::println!("Board Information:");
   stream::println!(
     "VideoCore Firmware rev: {}",
-    &board_info.videocore_firmware_rev
+    board_info.videocore_firmware_rev
   );
-  stream::println!("Board type: {}", &board_info.board_type);
-  stream::println!("Board model: {}", &board_info.board_model);
-  stream::println!("MAC Address: {}", &board_info.board_mac_address);
-  stream::println!("Serial: {:010x}", &board_info.board_serial);
-  stream::println!("ARM");
-  stream::println!(
-    "\tBase address: {:#010x}",
-    &board_info.arm_mem_base_address
-  );
-  stream::println!("\tSize: {} bytes", &board_info.arm_mem_size_bytes);
-  stream::println!("VideoCore");
-  stream::println!(
-    "\tBase address: {:#010x}",
-    &board_info.videocore_mem_base_address
-  );
-  stream::println!("\tSize: {} bytes", &board_info.videocore_mem_size_bytes);
+  stream::println!("Board type: {}", board_info.board_type);
+  stream::println!("Board model: {}", board_info.board_model);
+  stream::println!("MAC Address: {}", board_info.board_mac_address);
+  stream::println!("Serial: {:010x}", board_info.board_serial);
 
-  stream::println!();
+  // Display ARM and VideoCore memory regions
+  MemoryRegion::new(
+    board_info.arm_mem_base_address,
+    board_info.arm_mem_size_bytes,
+  )
+  .display("ARM Memory");
+  MemoryRegion::new(
+    board_info.videocore_mem_base_address,
+    board_info.videocore_mem_size_bytes,
+  )
+  .display("VideoCore Memory");
+}
+
+/// Displays CPU information including MMU and cache details
+fn display_cpu_info(memory_model: &cpu_info::MemoryModel) {
   stream::println!("===================================");
-  stream::println!("Test CPU info");
+  stream::println!("CPU Information:");
 
-  let memory_model = cpu_info::get_memory_model();
-  /*
-  ARMv8-A memory model:
-  When the Stage 1 MMU is disabled:
-  - All data accesses are Device_nGnRnE. We will explain this later in this guide.
-  - All instruction fetches are treated as cacheable.
-  - All addresses have read/write access and are executable.
-  */
   stream::println!("Stage 1 MMU enabled: {}", memory_model.mmu_enabled);
-
-  for cache_info in memory_model.cache {
-    stream::println!();
-    print_cache_info(&cache_info);
+  if !memory_model.mmu_enabled {
+    stream::println!("Note: When MMU is disabled:");
+    stream::println!("\t- All data accesses are Device_nGnRnE");
+    stream::println!("\t- All instruction fetches are treated as cacheable");
+    stream::println!(
+      "\t- All addresses have read/write access and are executable"
+    );
   }
 
-  stream::println!();
-  stream::println!("Test OK");
+  for cache_info in &memory_model.cache {
+    stream::println!();
+    display_cache_info(cache_info);
+  }
+}
+
+/// Entry point for displaying board and CPU information
+pub fn test_board_info() -> ! {
+  uart::pl011_init();
+  stream::println!("Starting Board Information Test");
+
+  let board_info = board_info::raspi_board_info();
+  display_board_info(&board_info);
+
+  let memory_model = cpu_info::get_memory_model();
+  display_cpu_info(&memory_model);
+
+  stream::println!("\nTest completed successfully");
   loop {}
 }
+
+#[cfg(test)]
+#[path = "board_info_test.rs"]
+mod board_info_test;

--- a/src/diagnostic/board_info.rs
+++ b/src/diagnostic/board_info.rs
@@ -2,124 +2,133 @@ use crate::common::stream;
 use crate::io::uart;
 use crate::meta::{board_info, cpu_info};
 
+/// Constants for better readability and maintenance
 const BYTES_PER_KIB: usize = 1024;
 
-/// Represents and displays a memory region
+/// Struct for displaying memory region information
 struct MemoryRegion {
-  base_address: usize,
-  size_bytes: usize,
+    base_address: usize,
+    size_bytes: usize,
 }
 
 impl MemoryRegion {
-  fn new(base_address: u32, size_bytes: u32) -> Self {
-    Self {
-      base_address: base_address as usize,
-      size_bytes: size_bytes as usize,
+    fn new(base_address: usize, size_bytes: usize) -> Self {
+        Self {
+            base_address,
+            size_bytes,
+        }
     }
-  }
 
-  fn display(&self, region_name: &str) {
-    stream::println!("{}:", region_name);
-    stream::println!("\tBase address: {:#010x}", self.base_address);
-    stream::println!("\tSize: {} bytes", self.size_bytes);
-  }
+    fn display(&self, region_name: &str) {
+        stream::println!("{}", region_name);
+        stream::println!("\tBase address: {:#010x}", self.base_address);
+        stream::println!("\tSize: {} bytes", self.size_bytes);
+    }
 }
 
-/// Handles the display of cache information
-fn display_cache_info(cache: &cpu_info::CacheInfo) {
-  stream::println!("Cache Level {} - {}", cache.level, cache.cache_type);
+/// Prints detailed information about a given cache level, including size and capabilities.
+fn print_cache_info(cache: &cpu_info::CacheInfo) {
+    stream::println!("Cache Level {} - {}", cache.level, cache.cache_type);
+    
+    if !cache.exists {
+        stream::println!("Cache does not exist");
+        return;
+    }
 
-  if !cache.exists {
-    stream::println!("Cache does not exist");
-    return;
-  }
-
-  stream::println!("Size Information:");
-  stream::println!("\tLine size: {} bytes", cache.line_size_bytes);
-  stream::println!("\tAssociativity: {}", cache.associativity);
-  stream::println!("\tNumber of sets: {}", cache.num_sets);
-  stream::println!(
-    "\tTotal size: {} bytes ({} KiB)",
-    cache.total_size_bytes,
-    cache.total_size_bytes / BYTES_PER_KIB as u32
-  );
-
-  stream::println!("Cache Capabilities:");
-  stream::println!("\tWrite allocation: {}", cache.write_alloc_supported);
-  stream::println!("\tRead allocation: {}", cache.read_alloc_supported);
-  stream::println!("\tWrite back: {}", cache.write_back_supported);
-  stream::println!("\tWrite through: {}", cache.write_through_supported);
-}
-
-/// Displays general board information including memory regions
-fn display_board_info(board_info: &board_info::RaspiBoardInfo) {
-  stream::println!("===================================");
-  stream::println!("Board Information:");
-  stream::println!(
-    "VideoCore Firmware rev: {}",
-    board_info.videocore_firmware_rev
-  );
-  stream::println!("Board type: {}", board_info.board_type);
-  stream::println!("Board model: {}", board_info.board_model);
-  stream::println!("MAC Address: {}", board_info.board_mac_address);
-  stream::println!("Serial: {:010x}", board_info.board_serial);
-
-  // Display ARM and VideoCore memory regions
-  MemoryRegion::new(
-    board_info.arm_mem_base_address,
-    board_info.arm_mem_size_bytes,
-  )
-  .display("ARM Memory");
-  MemoryRegion::new(
-    board_info.videocore_mem_base_address,
-    board_info.videocore_mem_size_bytes,
-  )
-  .display("VideoCore Memory");
-}
-
-/// Displays CPU information including MMU and cache details
-fn display_cpu_info(memory_model: &cpu_info::MemoryModel) {
-  stream::println!("===================================");
-  stream::println!("CPU Information:");
-
-  /*
-  ARMv8-A memory model:
-  When the Stage 1 MMU is disabled:
-  - All data accesses are Device_nGnRnE. We will explain this later in this guide.
-  - All instruction fetches are treated as cacheable.
-  - All addresses have read/write access and are executable.
-  */
-  stream::println!("Stage 1 MMU enabled: {}", memory_model.mmu_enabled);
-  if !memory_model.mmu_enabled {
-    stream::println!("Note: When MMU is disabled:");
-    stream::println!("\t- All data accesses are Device_nGnRnE");
-    stream::println!("\t- All instruction fetches are treated as cacheable");
+    stream::println!("Size Information:");
+    stream::println!("\tLine size: {} bytes", cache.line_size_bytes);
+    stream::println!("\tAssociativity: {}", cache.associativity);
+    stream::println!("\tNumber of sets: {}", cache.num_sets);
     stream::println!(
-      "\t- All addresses have read/write access and are executable"
+        "\tTotal size: {} bytes ({} KiB)",
+        cache.total_size_bytes,
+        cache.total_size_bytes / BYTES_PER_KIB as u32
     );
-  }
 
-  for cache_info in &memory_model.cache {
-    stream::println!();
-    display_cache_info(cache_info);
-  }
+    stream::println!("Cache Capabilities:");
+    stream::println!("\tWrite allocation: {}", cache.write_alloc_supported);
+    stream::println!("\tRead allocation: {}", cache.read_alloc_supported);
+    stream::println!("\tWrite back: {}", cache.write_back_supported);
+    stream::println!("\tWrite through: {}", cache.write_through_supported);
 }
 
-/// Entry point for displaying board and CPU information
+/// Displays information about the Raspberry Pi board, including firmware, type, and memory layout.
+fn print_board_info(board_info: &board_info::RaspiBoardInfo) {
+    stream::println!("===================================");
+    stream::println!("Board Information:");
+    stream::println!("VideoCore Firmware rev: {}", board_info.videocore_firmware_rev);
+    stream::println!("Board type: {}", board_info.board_type);
+    stream::println!("Board model: {}", board_info.board_model);
+    stream::println!("MAC Address: {}", board_info.board_mac_address);
+    stream::println!("Serial: {:010x}", board_info.board_serial);
+
+    // Display ARM and VideoCore memory regions
+    let arm_memory = MemoryRegion::new(
+        board_info.arm_mem_base_address as usize,
+        board_info.arm_mem_size_bytes as usize,
+    );
+    let videocore_memory = MemoryRegion::new(
+        board_info.videocore_mem_base_address as usize,
+        board_info.videocore_mem_size_bytes as usize,
+    );
+
+    arm_memory.display("ARM Memory:");
+    videocore_memory.display("VideoCore Memory:");
+}
+
+/**
+ * Prints the CPU information, focusing on the MMU (Memory Management Unit) status.
+ * 
+ * ## MMU State Information:
+ * 
+ * **ARMv8-A Memory Model (when Stage 1 MMU is disabled)**:
+ * 
+ * - **Data Accesses**: All data accesses are treated as `Device_nGnRnE` (Device Non-Gathering, 
+ *   Non-Reordering, Non-Early write acknowledgment). This restricts caching and enforces 
+ *   strict ordering for memory-mapped devices to ensure accurate I/O operations.
+ * - **Instruction Fetches**: Treated as cacheable, allowing fast access to instructions but 
+ *   without strict protection control.
+ * - **Access Permissions**: All addresses have full read/write permissions and are executable. 
+ *   This disables address-based permissions, making memory access permissive.
+ * 
+ * The MMU enables virtual memory mappings, providing memory protection, address translation, 
+ * and isolation. When enabled, this allows for more efficient use of memory resources 
+ * and greater control over process isolation and memory security.
+ * 
+ * - `Stage 1 MMU enabled`: Indicates if the first stage of the MMU is active.
+ */
+fn print_cpu_info(memory_model: &cpu_info::MemoryModel) {
+    stream::println!("===================================");
+    stream::println!("CPU Information:");
+    
+    stream::println!("Stage 1 MMU enabled: {}", memory_model.mmu_enabled);
+    if !memory_model.mmu_enabled {
+        stream::println!("Note: ARMv8-A memory model when Stage 1 MMU is disabled:");
+        stream::println!("\t- All data accesses are Device_nGnRnE (non-cacheable, non-shareable).");
+        stream::println!("\t- All instruction fetches are treated as cacheable.");
+        stream::println!("\t- All addresses have read/write access and are executable.");
+    }
+
+    for cache_info in &memory_model.cache {
+        stream::println!();
+        print_cache_info(cache_info);
+    }
+}
+
+/// Entry point for the board information test. Initializes UART for serial output,
+/// retrieves board and CPU information, and displays both through the UART stream.
+///
+/// This function runs in a continuous loop after output to indicate the completion of the test.
 pub fn test_board_info() -> ! {
-  uart::pl011_init();
-  stream::println!("Starting Board Information Test");
+    uart::pl011_init();
+    stream::println!("Starting Board Information Test");
 
-  let board_info = board_info::raspi_board_info();
-  display_board_info(&board_info);
+    let board_info = board_info::raspi_board_info();
+    print_board_info(&board_info);
 
-  let memory_model = cpu_info::get_memory_model();
-  display_cpu_info(&memory_model);
+    let memory_model = cpu_info::get_memory_model();
+    print_cpu_info(&memory_model);
 
-  stream::println!("\nTest completed successfully");
-  loop {}
+    stream::println!("\nTest completed successfully");
+    loop {}
 }
-
-#[cfg(test)]
-#[path = "board_info_test.rs"]
-mod board_info_test;

--- a/src/diagnostic/board_info.rs
+++ b/src/diagnostic/board_info.rs
@@ -82,6 +82,13 @@ fn display_cpu_info(memory_model: &cpu_info::MemoryModel) {
   stream::println!("===================================");
   stream::println!("CPU Information:");
 
+  /*
+  ARMv8-A memory model:
+  When the Stage 1 MMU is disabled:
+  - All data accesses are Device_nGnRnE. We will explain this later in this guide.
+  - All instruction fetches are treated as cacheable.
+  - All addresses have read/write access and are executable.
+  */
   stream::println!("Stage 1 MMU enabled: {}", memory_model.mmu_enabled);
   if !memory_model.mmu_enabled {
     stream::println!("Note: When MMU is disabled:");

--- a/src/diagnostic/board_info_test.rs
+++ b/src/diagnostic/board_info_test.rs
@@ -1,0 +1,188 @@
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::common::error::ErrorKind;
+  use crate::common::stream::{set_out, OutputOps};
+  use crate::diagnostic::board_info::{display_board_info, display_cpu_info};
+  use crate::meta::board_info::MacAddress;
+  use crate::meta::board_info::RaspiBoardType;
+  use crate::meta::cpu_info::{CacheLevel, CacheType};
+  use crate::meta::{board_info, cpu_info};
+  use core::fmt::{self, Write};
+  use lazy_static::lazy_static;
+  use std::sync::Mutex;
+
+  // Define a static buffer to capture printed output
+  lazy_static! {
+    static ref TEST_BUFFER: Mutex<TestBuffer> = Mutex::new(TestBuffer::new());
+  }
+
+  struct TestBuffer {
+    buffer: Vec<u8>,
+  }
+
+  impl TestBuffer {
+    fn new() -> Self {
+      Self { buffer: Vec::new() }
+    }
+
+    fn contents(&self) -> String {
+      String::from_utf8_lossy(&self.buffer).into_owned()
+    }
+
+    fn clear(&mut self) {
+      self.buffer.clear();
+    }
+  }
+
+  impl Write for TestBuffer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+      self.buffer.extend_from_slice(s.as_bytes());
+      Ok(())
+    }
+  }
+
+  // Proxy function to write to the TEST_BUFFER
+  fn write_to_test_buffer(s: &str) -> Result<(), ErrorKind> {
+    let mut buffer = TEST_BUFFER.lock().unwrap();
+    buffer.write_str(s).map_err(|_| ErrorKind::Uncategorized)
+  }
+
+  // Set up a test output environment and return a reference to TEST_BUFFER
+  fn setup_test_output() -> &'static Mutex<TestBuffer> {
+    let output_ops = OutputOps {
+      write: write_to_test_buffer,
+    };
+    set_out(output_ops);
+
+    let mut buffer = TEST_BUFFER.lock().unwrap();
+    buffer.clear();
+    &TEST_BUFFER
+  }
+
+  // Test for displaying board information
+  #[test]
+  fn test_display_board_info() {
+    let test_buffer = setup_test_output();
+
+    // Mock data for testing
+    let mock_board_info = board_info::RaspiBoardInfo {
+      videocore_firmware_rev: 12345,
+      board_type: RaspiBoardType::Pi4,
+      board_model: 4,
+      board_mac_address: MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+      board_serial: 0x123456789ABCDEF,
+      arm_mem_base_address: 0x1000,
+      arm_mem_size_bytes: 1024 * 1024, // 1 MB
+      videocore_mem_base_address: 0x2000,
+      videocore_mem_size_bytes: 512 * 1024, // 512 KB
+    };
+
+    display_board_info(&mock_board_info);
+    let output = test_buffer.lock().unwrap().contents();
+    assert!(output.contains("Board Information:"));
+    assert!(output.contains("VideoCore Firmware rev: 12345"));
+    assert!(output.contains("Board type: Pi4"));
+    assert!(output.contains("MAC Address: aa:bb:cc:dd:ee:ff"));
+    assert!(output.contains("Serial: 123456789abcdef"));
+    assert!(output.contains("ARM Memory:"));
+    assert!(output.contains("Base address: 0x00001000"));
+    assert!(output.contains("Size: 1048576 bytes"));
+    assert!(output.contains("VideoCore Memory:"));
+    assert!(output.contains("Base address: 0x00002000"));
+    assert!(output.contains("Size: 524288 bytes"));
+  }
+
+  // Test for displaying cpu information
+  #[test]
+  fn test_display_cpu_info() {
+    setup_test_output();
+
+    // Mock CPU information data
+    let mock_memory_model = cpu_info::MemoryModel {
+      mmu_enabled: true,
+      cache: [
+        cpu_info::CacheInfo {
+          level: CacheLevel::L1,
+          cache_type: CacheType::Data,
+          exists: true,
+          line_size_bytes: 64,
+          associativity: 4,
+          num_sets: 128,
+          total_size_bytes: 32768, // 32 KB
+          write_alloc_supported: true,
+          read_alloc_supported: true,
+          write_back_supported: true,
+          write_through_supported: false,
+        },
+        cpu_info::CacheInfo {
+          level: CacheLevel::L2,
+          cache_type: CacheType::Unified,
+          exists: false,
+          line_size_bytes: 0,
+          associativity: 0,
+          num_sets: 0,
+          total_size_bytes: 0,
+          write_alloc_supported: false,
+          read_alloc_supported: false,
+          write_back_supported: false,
+          write_through_supported: false,
+        },
+        cpu_info::CacheInfo {
+          level: CacheLevel::L3,
+          cache_type: CacheType::Unified,
+          exists: true,
+          line_size_bytes: 64,
+          associativity: 8,
+          num_sets: 256,
+          total_size_bytes: 2097152, // 2 MB
+          write_alloc_supported: true,
+          read_alloc_supported: true,
+          write_back_supported: true,
+          write_through_supported: false,
+        },
+        cpu_info::CacheInfo {
+          level: CacheLevel::L3,
+          cache_type: CacheType::Unified,
+          exists: false,
+          line_size_bytes: 0,
+          associativity: 0,
+          num_sets: 0,
+          total_size_bytes: 0,
+          write_alloc_supported: false,
+          read_alloc_supported: false,
+          write_back_supported: false,
+          write_through_supported: false,
+        },
+      ],
+    };
+
+    // Run function and capture output
+    display_cpu_info(&mock_memory_model);
+    let output = TEST_BUFFER.lock().unwrap().contents();
+
+    println!("Captured output:\n{}", output);
+
+    // Assertions for CPU information
+    assert!(output.contains("CPU Information:"));
+    assert!(output.contains("Stage 1 MMU enabled: true"));
+    assert!(output.contains("Cache Level L1 - data"));
+    assert!(output.contains("Size Information:"));
+    assert!(output.contains("Line size: 64 bytes"));
+    assert!(output.contains("Associativity: 4"));
+    assert!(output.contains("Number of sets: 128"));
+    assert!(output.contains("Total size: 32768 bytes (32 KiB)"));
+    assert!(output.contains("Write allocation: true"));
+    assert!(output.contains("Read allocation: true"));
+    assert!(output.contains("Write back: true"));
+    assert!(output.contains("Write through: false"));
+
+    // Assertions for non-existent cache levels
+    assert!(output.contains("Cache Level L2 - unified"));
+    assert!(output.contains("Cache does not exist"));
+
+    // Assertions for L3 cache
+    assert!(output.contains("Cache Level L3 - unified"));
+    assert!(output.contains("Total size: 2097152 bytes (2048 KiB)"));
+  }
+}

--- a/src/meta/board_info.rs
+++ b/src/meta/board_info.rs
@@ -37,6 +37,12 @@ pub struct MacAddress {
   data: [u8; 6],
 }
 
+impl MacAddress {
+  pub fn new(data: [u8; 6]) -> Self {
+    MacAddress { data }
+  }
+}
+
 impl core::fmt::Display for MacAddress {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     write!(


### PR DESCRIPTION
This commit introduces several improvements to the board information testing module to enhance code organization, maintainability, and output clarity.

Key changes:
- Split large test_board_info function into focused subfunctions
- Introduce MemoryRegion struct for consistent memory info handling
- Add BYTES_PER_KIB constant to eliminate magic numbers
- Improve output formatting and section organization
- Fix grammar in error messages
- Enhance documentation of MMU state information

The changes make the code more modular and easier to maintain while providing clearer, more structured output for system information.

Part-of: system-info-improvements