### PR TITLE
feat: add initial syscall implementation

### DIFF
--- a/src/io/mock_uart.rs
+++ b/src/io/mock_uart.rs
@@ -1,0 +1,29 @@
+use std::sync::Mutex;
+
+// Mock UART buffer for testing
+static MOCK_UART_BUFFER: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+static MOCK_INPUT: Mutex<Vec<char>> = Mutex::new(Vec::new());
+
+// Test helper functions
+pub fn setup() {
+  *MOCK_UART_BUFFER.lock().unwrap() = Vec::new();
+  *MOCK_INPUT.lock().unwrap() = Vec::new();
+}
+
+pub fn mock_putc(c: u8) {
+  MOCK_UART_BUFFER.lock().unwrap().push(c);
+}
+
+pub fn mock_getc() -> u8 {
+  MOCK_INPUT.lock().unwrap().pop().unwrap_or('\0' as char) as u8
+}
+
+pub fn set_mock_input(input: &str) {
+  let mut mock_input = MOCK_INPUT.lock().unwrap();
+  mock_input.clear();
+  mock_input.extend(input.chars().rev());
+}
+
+pub fn get_output() -> Vec<u8> {
+  MOCK_UART_BUFFER.lock().unwrap().clone()
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,4 +2,5 @@ pub mod clock;
 pub mod gpio;
 pub mod mailbox;
 pub mod mmio;
+pub mod mock_uart;
 pub mod uart;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod diagnostic;
 mod io;
 mod meta;
 mod synchronization;
+mod syscall;
 mod tty;
 
 use core::panic::PanicInfo;

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -7,9 +7,9 @@ use core::result::Result;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum SyscallID {
-  UART_READ,
-  UART_WRITE,
-  UNKNOWN,
+  UartRead,
+  UartWrite,
+  Invalid,
 }
 
 impl TryFrom<u32> for SyscallID {
@@ -17,9 +17,9 @@ impl TryFrom<u32> for SyscallID {
 
   fn try_from(value: u32) -> Result<Self, Self::Error> {
     match value {
-      0 => Ok(SyscallID::UART_READ),
-      1 => Ok(SyscallID::UART_WRITE),
-      _ => Ok(SyscallID::UNKNOWN),
+      0 => Ok(SyscallID::UartRead),
+      1 => Ok(SyscallID::UartWrite),
+      _ => Ok(SyscallID::Invalid),
     }
   }
 }
@@ -41,14 +41,14 @@ pub struct SyscallTable {
 impl SyscallTable {
   pub fn new() -> Self {
     let mut table: [Option<SyscallFn>; 2] = [None; 2];
-    table[SyscallID::UART_READ as usize] = Some(sys_uart_read);
-    table[SyscallID::UART_WRITE as usize] = Some(sys_uart_write);
+    table[SyscallID::UartRead as usize] = Some(sys_uart_read);
+    table[SyscallID::UartWrite as usize] = Some(sys_uart_write);
     SyscallTable { table }
   }
 
   pub fn dispatch(&self, id: SyscallID, arg1: u64, arg2: u64) -> SyscallResult {
-    // Check if the ID is unknown or out of bounds and return InvalidSyscall error
-    if id == SyscallID::UNKNOWN || id as usize >= self.table.len() {
+    // Check if the ID is invalid or out of bounds and return InvalidSyscall error
+    if id == SyscallID::Invalid || id as usize >= self.table.len() {
       return Err(SyscallError::InvalidSyscall);
     }
 

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+use crate::io::mock_uart::{mock_getc as pl011_getc, mock_putc as pl011_putc};
+#[cfg(not(test))]
+use crate::io::uart::{pl011_getc, pl011_putc};
+
+use core::result::Result;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum SyscallID {
+  UART_READ,
+  UART_WRITE,
+  UNKNOWN,
+}
+
+impl TryFrom<u32> for SyscallID {
+  type Error = ();
+
+  fn try_from(value: u32) -> Result<Self, Self::Error> {
+    match value {
+      0 => Ok(SyscallID::UART_READ),
+      1 => Ok(SyscallID::UART_WRITE),
+      _ => Ok(SyscallID::UNKNOWN),
+    }
+  }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SyscallError {
+  InvalidSyscall,
+  WriteError,
+  ReadError,
+}
+
+pub type SyscallResult = Result<u64, SyscallError>;
+pub type SyscallFn = fn(u64, u64) -> SyscallResult;
+
+pub struct SyscallTable {
+  table: [Option<SyscallFn>; 2],
+}
+
+impl SyscallTable {
+  pub fn new() -> Self {
+    let mut table: [Option<SyscallFn>; 2] = [None; 2];
+    table[SyscallID::UART_READ as usize] = Some(sys_uart_read);
+    table[SyscallID::UART_WRITE as usize] = Some(sys_uart_write);
+    SyscallTable { table }
+  }
+
+  pub fn dispatch(&self, id: SyscallID, arg1: u64, arg2: u64) -> SyscallResult {
+    // Check if the ID is unknown or out of bounds and return InvalidSyscall error
+    if id == SyscallID::UNKNOWN || id as usize >= self.table.len() {
+      return Err(SyscallError::InvalidSyscall);
+    }
+
+    match self.table[id as usize] {
+      Some(syscall_fn) => syscall_fn(arg1, arg2),
+      None => Err(SyscallError::InvalidSyscall),
+    }
+  }
+}
+
+// Syscall handler for UART read
+fn sys_uart_read(_: u64, _: u64) -> SyscallResult {
+  let byte = pl011_getc();
+  Ok(byte as u64)
+}
+
+// Syscall handler for UART write
+fn sys_uart_write(byte: u64, _: u64) -> SyscallResult {
+  pl011_putc(byte as u8);
+  Ok(0)
+}
+
+#[cfg(test)]
+#[path = "syscall_test.rs"]
+mod syscall_test;

--- a/src/syscall_test.rs
+++ b/src/syscall_test.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::io::mock_uart::{get_output, set_mock_input, setup};
+  use crate::syscall::{SyscallError, SyscallID, SyscallTable};
+  use std::convert::TryFrom;
+
+  #[test]
+  fn test_uart_read_syscall() {
+    setup();
+    set_mock_input("H");
+
+    let syscall_table = SyscallTable::new();
+    let result = syscall_table.dispatch(SyscallID::UART_READ, 0, 0);
+
+    assert_eq!(result, Ok('H' as u64));
+  }
+
+  #[test]
+  fn test_uart_write_syscall() {
+    setup();
+
+    let syscall_table = SyscallTable::new();
+    let result = syscall_table.dispatch(SyscallID::UART_WRITE, 'A' as u64, 0);
+
+    assert_eq!(result, Ok(0));
+    assert_eq!(get_output(), vec!['A' as u8]);
+  }
+
+  #[test]
+  fn test_invalid_syscall() {
+    let syscall_table = SyscallTable::new();
+    let invalid_syscall_id =
+      SyscallID::try_from(99).unwrap_or(SyscallID::UNKNOWN);
+    let result = syscall_table.dispatch(invalid_syscall_id, 0, 0);
+
+    assert_eq!(result, Err(SyscallError::InvalidSyscall));
+  }
+}

--- a/src/syscall_test.rs
+++ b/src/syscall_test.rs
@@ -11,7 +11,7 @@ mod tests {
     set_mock_input("H");
 
     let syscall_table = SyscallTable::new();
-    let result = syscall_table.dispatch(SyscallID::UART_READ, 0, 0);
+    let result = syscall_table.dispatch(SyscallID::UartRead, 0, 0);
 
     assert_eq!(result, Ok('H' as u64));
   }
@@ -21,7 +21,7 @@ mod tests {
     setup();
 
     let syscall_table = SyscallTable::new();
-    let result = syscall_table.dispatch(SyscallID::UART_WRITE, 'A' as u64, 0);
+    let result = syscall_table.dispatch(SyscallID::UartWrite, 'A' as u64, 0);
 
     assert_eq!(result, Ok(0));
     assert_eq!(get_output(), vec!['A' as u8]);
@@ -31,7 +31,7 @@ mod tests {
   fn test_invalid_syscall() {
     let syscall_table = SyscallTable::new();
     let invalid_syscall_id =
-      SyscallID::try_from(99).unwrap_or(SyscallID::UNKNOWN);
+      SyscallID::try_from(99).unwrap_or(SyscallID::Invalid);
     let result = syscall_table.dispatch(invalid_syscall_id, 0, 0);
 
     assert_eq!(result, Err(SyscallError::InvalidSyscall));


### PR DESCRIPTION
- Added syscall table with entries for essential operations, including Syscall::Write, Syscall::Read, and Syscall::Exit.