### PR TITLE
[feat] Implement Interrupt Handling and Integrate with Syscall Interface

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,119 @@
+use core::result::Result;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum InterruptType {
+  Timer,
+  Uart,
+  Unknown,
+}
+
+impl TryFrom<u32> for InterruptType {
+  type Error = ();
+
+  fn try_from(value: u32) -> Result<Self, Self::Error> {
+    match value {
+      0 => Ok(InterruptType::Timer),
+      1 => Ok(InterruptType::Uart),
+      _ => Ok(InterruptType::Unknown),
+    }
+  }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum InterruptError {
+  InvalidHandler,
+  HandlerExists,
+  UnknownInterrupt,
+}
+
+pub type InterruptResult = Result<(), InterruptError>;
+pub type InterruptHandler = fn() -> InterruptResult;
+
+pub struct InterruptController {
+  handlers: [Option<InterruptHandler>; 2],
+  interrupts_enabled: AtomicBool,
+}
+
+impl InterruptController {
+  pub fn new() -> Self {
+    InterruptController {
+      handlers: [None; 2],
+      interrupts_enabled: AtomicBool::new(false),
+    }
+  }
+
+  /// Register a handler for a specific interrupt type
+  pub fn register_handler(
+    &mut self,
+    int_type: InterruptType,
+    handler: InterruptHandler,
+  ) -> InterruptResult {
+    if int_type == InterruptType::Unknown {
+      return Err(InterruptError::UnknownInterrupt);
+    }
+
+    let idx = int_type as usize;
+    if idx >= self.handlers.len() {
+      return Err(InterruptError::InvalidHandler);
+    }
+
+    if self.handlers[idx].is_some() {
+      return Err(InterruptError::HandlerExists);
+    }
+
+    self.handlers[idx] = Some(handler);
+    Ok(())
+  }
+
+  /// Handle an interrupt of the specified type
+  pub fn handle_interrupt(&self, int_type: InterruptType) -> InterruptResult {
+    if !self.interrupts_enabled.load(Ordering::SeqCst) {
+      return Ok(());
+    }
+
+    if int_type == InterruptType::Unknown {
+      return Err(InterruptError::UnknownInterrupt);
+    }
+
+    let idx = int_type as usize;
+    if idx >= self.handlers.len() {
+      return Err(InterruptError::InvalidHandler);
+    }
+
+    match self.handlers[idx] {
+      Some(handler) => handler(),
+      None => Ok(()),
+    }
+  }
+
+  /// Enable interrupts globally
+  pub fn enable_interrupts(&self) {
+    self.interrupts_enabled.store(true, Ordering::SeqCst);
+  }
+
+  /// Disable interrupts globally
+  pub fn disable_interrupts(&self) {
+    self.interrupts_enabled.store(false, Ordering::SeqCst);
+  }
+
+  /// Check if interrupts are enabled
+  pub fn are_interrupts_enabled(&self) -> bool {
+    self.interrupts_enabled.load(Ordering::SeqCst)
+  }
+}
+
+// Example interrupt handlers
+pub fn timer_handler() -> InterruptResult {
+  // Handle timer interrupt
+  Ok(())
+}
+
+pub fn uart_handler() -> InterruptResult {
+  // Handle UART interrupt
+  Ok(())
+}
+
+#[cfg(test)]
+#[path = "interrupt_test.rs"]
+mod interrupt_test;

--- a/src/interrupt_test.rs
+++ b/src/interrupt_test.rs
@@ -1,0 +1,57 @@
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::interrupt::{
+    timer_handler, uart_handler, InterruptController, InterruptError,
+    InterruptHandler, InterruptType,
+  };
+
+  #[test]
+  fn test_interrupt_registration() {
+    let mut controller = InterruptController::new();
+
+    // Test successful registration
+    assert!(controller
+      .register_handler(InterruptType::Timer, timer_handler)
+      .is_ok());
+
+    // Test duplicate registration
+    assert_eq!(
+      controller.register_handler(InterruptType::Timer, timer_handler),
+      Err(InterruptError::HandlerExists)
+    );
+
+    // Test unknown interrupt
+    assert_eq!(
+      controller.register_handler(InterruptType::Unknown, timer_handler),
+      Err(InterruptError::UnknownInterrupt)
+    );
+  }
+
+  #[test]
+  fn test_interrupt_handling() {
+    let mut controller = InterruptController::new();
+
+    // Register handlers
+    controller
+      .register_handler(InterruptType::Timer, timer_handler)
+      .unwrap();
+    controller
+      .register_handler(InterruptType::Uart, uart_handler)
+      .unwrap();
+
+    // Test with interrupts disabled
+    assert!(controller.handle_interrupt(InterruptType::Timer).is_ok());
+
+    // Enable interrupts and test
+    controller.enable_interrupts();
+    assert!(controller.handle_interrupt(InterruptType::Timer).is_ok());
+    assert!(controller.handle_interrupt(InterruptType::Uart).is_ok());
+
+    // Test unknown interrupt
+    assert_eq!(
+      controller.handle_interrupt(InterruptType::Unknown),
+      Err(InterruptError::UnknownInterrupt)
+    );
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod boot;
 mod common;
 mod container;
 mod diagnostic;
+mod interrupt;
 mod io;
 mod meta;
 mod synchronization;

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -1,14 +1,20 @@
+use crate::interrupt::{
+  timer_handler, InterruptController, InterruptError, InterruptHandler,
+  InterruptType,
+};
 #[cfg(test)]
 use crate::io::mock_uart::{mock_getc as pl011_getc, mock_putc as pl011_putc};
 #[cfg(not(test))]
 use crate::io::uart::{pl011_getc, pl011_putc};
-
 use core::result::Result;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum SyscallID {
   UartRead,
   UartWrite,
+  InterruptEnable,
+  InterruptDisable,
+  InterruptRegister,
   Invalid,
 }
 
@@ -19,6 +25,9 @@ impl TryFrom<u32> for SyscallID {
     match value {
       0 => Ok(SyscallID::UartRead),
       1 => Ok(SyscallID::UartWrite),
+      2 => Ok(SyscallID::InterruptEnable),
+      3 => Ok(SyscallID::InterruptDisable),
+      4 => Ok(SyscallID::InterruptRegister),
       _ => Ok(SyscallID::Invalid),
     }
   }
@@ -29,45 +38,123 @@ pub enum SyscallError {
   InvalidSyscall,
   WriteError,
   ReadError,
+  InterruptError,
+}
+
+impl From<InterruptError> for SyscallError {
+  fn from(_: InterruptError) -> Self {
+    SyscallError::InterruptError
+  }
 }
 
 pub type SyscallResult = Result<u64, SyscallError>;
 pub type SyscallFn = fn(u64, u64) -> SyscallResult;
 
 pub struct SyscallTable {
-  table: [Option<SyscallFn>; 2],
+  table: [Option<SyscallFn>; 5],
+  interrupt_controller: InterruptController,
 }
 
 impl SyscallTable {
   pub fn new() -> Self {
-    let mut table: [Option<SyscallFn>; 2] = [None; 2];
+    let mut table: [Option<SyscallFn>; 5] = [None; 5];
     table[SyscallID::UartRead as usize] = Some(sys_uart_read);
     table[SyscallID::UartWrite as usize] = Some(sys_uart_write);
-    SyscallTable { table }
+    table[SyscallID::InterruptEnable as usize] = Some(sys_interrupt_enable);
+    table[SyscallID::InterruptDisable as usize] = Some(sys_interrupt_disable);
+    table[SyscallID::InterruptRegister as usize] = Some(sys_interrupt_register);
+
+    SyscallTable {
+      table,
+      interrupt_controller: InterruptController::new(),
+    }
   }
 
-  pub fn dispatch(&self, id: SyscallID, arg1: u64, arg2: u64) -> SyscallResult {
-    // Check if the ID is invalid or out of bounds and return InvalidSyscall error
+  pub fn dispatch(
+    &mut self,
+    id: SyscallID,
+    arg1: u64,
+    arg2: u64,
+  ) -> SyscallResult {
     if id == SyscallID::Invalid || id as usize >= self.table.len() {
       return Err(SyscallError::InvalidSyscall);
     }
 
     match self.table[id as usize] {
-      Some(syscall_fn) => syscall_fn(arg1, arg2),
+      Some(syscall_fn) => match id {
+        SyscallID::InterruptRegister => {
+          self.handle_interrupt_registration(arg1, arg2)
+        }
+        SyscallID::InterruptEnable => {
+          self.interrupt_controller.enable_interrupts();
+          syscall_fn(arg1, arg2)
+        }
+        SyscallID::InterruptDisable => {
+          self.interrupt_controller.disable_interrupts();
+          syscall_fn(arg1, arg2)
+        }
+        _ => syscall_fn(arg1, arg2),
+      },
       None => Err(SyscallError::InvalidSyscall),
     }
   }
+
+  fn handle_interrupt_registration(
+    &mut self,
+    int_type: u64,
+    handler_addr: u64,
+  ) -> SyscallResult {
+    let int_type_u32 =
+      u32::try_from(int_type).map_err(|_| SyscallError::InterruptError)?;
+
+    let interrupt_type = InterruptType::try_from(int_type_u32)
+      .map_err(|_| SyscallError::InterruptError)?;
+
+    // Safety: Converting the handler address to a function pointer
+    let handler: InterruptHandler =
+      unsafe { core::mem::transmute(handler_addr) };
+
+    self
+      .interrupt_controller
+      .register_handler(interrupt_type, handler)
+      .map(|_| 0)
+      .map_err(Into::into)
+  }
+
+  pub fn handle_interrupt(
+    &self,
+    int_type: InterruptType,
+  ) -> Result<(), SyscallError> {
+    self
+      .interrupt_controller
+      .handle_interrupt(int_type)
+      .map_err(Into::into)
+  }
 }
 
-// Syscall handler for UART read
+// Syscall handlers
 fn sys_uart_read(_: u64, _: u64) -> SyscallResult {
   let byte = pl011_getc();
   Ok(byte as u64)
 }
 
-// Syscall handler for UART write
 fn sys_uart_write(byte: u64, _: u64) -> SyscallResult {
   pl011_putc(byte as u8);
+  Ok(0)
+}
+
+fn sys_interrupt_enable(_: u64, _: u64) -> SyscallResult {
+  // Platform-specific interrupt enable would go here
+  Ok(0)
+}
+
+fn sys_interrupt_disable(_: u64, _: u64) -> SyscallResult {
+  // Platform-specific interrupt disable would go here
+  Ok(0)
+}
+
+fn sys_interrupt_register(_int_type: u64, _handler_addr: u64) -> SyscallResult {
+  // The actual registration is handled in handle_interrupt_registration
   Ok(0)
 }
 


### PR DESCRIPTION
Description: This CL introduces interrupt handling within the SyscallTable, enabling syscall-based control over interrupt enablement, disablement, and handler registration. The changes provide a mechanism for the kernel to interact with device interrupts via syscalls, enhancing modularity and control over interrupt-driven events in user-space applications.

Changes Made:
Interrupt Handling Implementation:

Defined InterruptEnable, InterruptDisable, and InterruptRegister syscalls within SyscallID to support interrupt-related operations. Added InterruptController to manage interrupt states and handle enabling/disabling interrupts based on syscall requests. Syscall Integration with Interrupts:

Updated the SyscallTable to dispatch interrupt-related syscalls, including: Enable/Disable Interrupts: Direct calls to the interrupt controller’s enable and disable functions. Interrupt Registration: Added a mechanism to register interrupt handlers by address, enabling the kernel to dynamically assign handlers based on user-space requirements. Created helper methods like handle_interrupt_registration to validate interrupt types and safely convert handler addresses to function pointers for registration.